### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README
+++ b/README
@@ -28,7 +28,7 @@ faulthandler is implemented in C using signal handlers to be able to dump a
 traceback on a crash or when Python is blocked (eg. deadlock).
 
 Website:
-http://faulthandler.readthedocs.io/
+https://faulthandler.readthedocs.io/
 
 faulthandler is part of Python since Python 3.3:
 http://docs.python.org/dev/library/faulthandler.html

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,7 +43,7 @@ faulthandler works on Python 2.6-3.5. It is part of Python standard library
 since Python 3.3: `faulthandler module
 <http://docs.python.org/dev/library/faulthandler.html>`_
 
-* `faulthandler website <http://faulthandler.readthedocs.io/>`_
+* `faulthandler website <https://faulthandler.readthedocs.io/>`_
   (this page)
 * `faulthandler project at github
   <https://github.com/haypo/faulthandler/>`_: source code, bug tracker
@@ -305,7 +305,7 @@ Version 2.4 (2014-10-02)
 ------------------------
 
 * Add a new documentation written with Sphinx used to built a new website:
-  http://faulthandler.readthedocs.io/
+  https://faulthandler.readthedocs.io/
 * Python issue #19306: Add extra hints to faulthandler stack dumps that they
   are upside down.
 * Python issue #15463: the faulthandler module truncates strings to 500

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ options = {
     'license': "BSD (2-clause)",
     'description': 'Display the Python traceback on a crash',
     'long_description': long_description,
-    'url': "http://faulthandler.readthedocs.io/",
+    'url': "https://faulthandler.readthedocs.io/",
     'author': 'Victor Stinner',
     'author_email': 'victor.stinner@gmail.com',
     'ext_modules': [Extension('faulthandler', FILES)],


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.