### PR TITLE
Show the current timestamp in faulthandler_alarm

### DIFF
--- a/faulthandler.c
+++ b/faulthandler.c
@@ -151,6 +151,29 @@ extern const char* _Py_DumpTracebackThreads(
     PyInterpreterState *interp,
     PyThreadState *current_thread);
 
+
+#define TIMEBUFF_LEN 21 // enough space to represent a "long long" time
+static char _timebuff[TIMEBUFF_LEN] = {0};
+
+/* Return a pointer to a static buffer containing a string representation of the current unix timestamp
+ */
+char*
+timebuff(void)
+{
+    time_t value = time(NULL);
+
+    char * cur = _timebuff + TIMEBUFF_LEN - 1;
+    *cur = '\0';
+
+    while (value > 0 && cur > _timebuff) {
+        cur--;
+        *cur = (value % 10) + '0';
+        value = value / 10;
+    }
+    return cur;
+}
+
+
 /* Get the file descriptor of a file by calling its fileno() method and then
    call its flush() method.
 
@@ -506,6 +529,13 @@ faulthandler_alarm(int signum)
     _Py_write_noraise(fault_alarm.fd,
                       fault_alarm.header, fault_alarm.header_len);
 
+    const char* timestr = timebuff();
+    _Py_write_noraise(fault_alarm.fd,
+                      timestr, strlen(timestr));
+
+    _Py_write_noraise(fault_alarm.fd,
+                      "!\n", 2);
+
     /* PyThreadState_Get() doesn't give the state of the current thread if
        the thread doesn't hold the GIL. Read the thread local storage (TLS)
        instead: call PyGILState_GetThisThreadState(). */
@@ -542,11 +572,11 @@ format_timeout(double timeout)
 
     if (us != 0)
         PyOS_snprintf(buffer, sizeof(buffer),
-                      "Timeout (%lu:%02lu:%02lu.%06lu)!\n",
+                      "Timeout (%lu:%02lu:%02lu.%06lu) at UTC epoch ",
                       hour, min, sec, us);
     else
         PyOS_snprintf(buffer, sizeof(buffer),
-                      "Timeout (%lu:%02lu:%02lu)!\n",
+                      "Timeout (%lu:%02lu:%02lu) at UTC epoch ",
                       hour, min, sec);
 
     return strdup(buffer);


### PR DESCRIPTION
Single-commit version of https://github.com/haypo/faulthandler/pull/20

Hi! Here's a quick stab at printing the current time (as a unix timestamp) on scheduled thread-dumps (it's cumbersome to correlate otherwise).

Output looks like:

1455771515 Timeout (0:01:00)!
Not much else to mention... We use a single, static buffer to avoid allocating memory at dump time. Most of the added code is copied from cpython.

Builds and runs on OSX and Linux, can't test windows.