### PR TITLE
Issue #37 - Ignore non errors on Windows

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -271,6 +271,22 @@ class FaultHandlerTests(unittest.TestCase):
             3,
             'Floating point exception')
 
+    @skipIf(sys.platform != 'win32', 'specific to Windows')
+    def test_ignore_exception(self):
+        for exc_code in (
+            0xE06D7363,   # MSC exception ("Emsc")
+            0xE0434352,   # COM Callable Runtime exception ("ECCR")
+        ):
+            code = f"""
+                    import faulthandler
+                    faulthandler.enable()
+                    faulthandler._raise_exception({exc_code})
+                    """
+            code = dedent(code)
+            output, exitcode = self.get_output(code)
+            self.assertEqual(output, [])
+            self.assertEqual(exitcode, exc_code)
+
     @skipIf(not hasattr(signal, 'SIGBUS'), 'need signal.SIGBUS')
     def test_sigbus(self):
         self.check_fatal_error("""

--- a/tests.py
+++ b/tests.py
@@ -276,16 +276,17 @@ class FaultHandlerTests(unittest.TestCase):
         for exc_code in (
             0xE06D7363,   # MSC exception ("Emsc")
             0xE0434352,   # COM Callable Runtime exception ("ECCR")
+            0x40010006,   # Debug Print exception
         ):
-            code = f"""
+            code = """
                     import faulthandler
                     faulthandler.enable()
-                    faulthandler._raise_exception({exc_code})
-                    """
+                    faulthandler._raise_exception(0x%X)
+                    """ % exc_code
             code = dedent(code)
             output, exitcode = self.get_output(code)
             self.assertEqual(output, [])
-            self.assertEqual(exitcode, exc_code)
+            self.assertNotEqual(exitcode, 0)
 
     @skipIf(not hasattr(signal, 'SIGBUS'), 'need signal.SIGBUS')
     def test_sigbus(self):

--- a/tests.py
+++ b/tests.py
@@ -276,7 +276,6 @@ class FaultHandlerTests(unittest.TestCase):
         for exc_code in (
             0xE06D7363,   # MSC exception ("Emsc")
             0xE0434352,   # COM Callable Runtime exception ("ECCR")
-            0x40010006,   # Debug Print exception
         ):
             code = """
                     import faulthandler


### PR DESCRIPTION
This ports https://github.com/python/cpython/commit/2e4eee21301762c72d9f5b466ac49250b7a76bb3 to Python 2 and to this backport of the faulthandler. It prevents logging of non-error Windows exceptions, which can fill up a logfile very quickly with spurious tracebacks.